### PR TITLE
CI/CD Improvements

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -55,3 +55,6 @@ jobs:
                   message: ${{ steps.coverageComment.outputs.coverage }}%
                   color: ${{ steps.coverageComment.outputs.color }}
                   namedLogo: typescript
+
+            # Will add work here to build the docker container and deploy that
+            # container to Cloud Run, need to sort out containerization for that though

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-    pull_request:
+    push:
         branches:
             - main
 
@@ -39,6 +39,19 @@ jobs:
                   title: Jest Test Coverage
                   summary-title: Summary
                   badge-title: Coverage
+                  hide-comment: true
                   coverage-summary-path: ./coverage/coverage-summary.json
                   coverage-path: ./coverage.txt
                   junitxml-path: ./coverage/junit.xml
+
+            - name: Create the badge
+              if: github.ref == 'refs/heads/main'
+              uses: schneegans/dynamic-badges-action@v1.6.0
+              with:
+                  auth: ${{ secrets.COVERAGE_BADGE_GIST_TOKEN }}
+                  gistID: 54b0c842747fa6be3cd6d344631a1651
+                  filename: jest-coverage-comment__main.json
+                  label: Coverage
+                  message: ${{ steps.coverageComment.outputs.coverage }}%
+                  color: ${{ steps.coverageComment.outputs.color }}
+                  namedLogo: typescript

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # Todd Reborn Backend
 
-[![CI](https://github.com/hgermundsen/todd-reborn-backend/actions/workflows/continuous-integration.yaml/badge.svg)](https://github.com/hgermundsen/todd-reborn-backend/actions/workflows/continuous-integration.yaml)
+[![CI](https://github.com/hgermundsen/todd-reborn-backend/actions/workflows/continuous-integration.yaml/badge.svg)](https://github.com/hgermundsen/todd-reborn-backend/actions/workflows/continuous-integration.yaml) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/hgermundsen/54b0c842747fa6be3cd6d344631a1651/raw/coverage.json)
 
 ## What is Todd?
+
 Todd is an attempt at creating a "better" personal assistant experience than you'd get when using Siri or Google Assistant (or any generic voice based personal assistance for that matter). This is also a personal project of mine where I want to gain experience building out an architecture that I've designed, using tools and tech that I think is really neat. While using LLMs and AI based voice generation for something like this is very niche (and arguably overkill as hell), it's a fun idea that I'm passionate about and would love to eventually have support for others to use Todd as well.
 
 ## Planned/Supported Features
 
-- [x] Health Check Endpoint
-- [ ] To-Do List
-- [ ] Calendar events
-- [ ] Reminders
-- [ ] Weather Checking
-- [ ] Grocery List
-- [ ] Restaurant Planning/Picking
-- [ ] Meal Planning/Picking
+-   [x] Health Check Endpoint
+-   [ ] To-Do List
+-   [ ] Calendar events
+-   [ ] Reminders
+-   [ ] Weather Checking
+-   [ ] Grocery List
+-   [ ] Restaurant Planning/Picking
+-   [ ] Meal Planning/Picking
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.3.12",
         "@types/multer": "^1.4.7",
+        "jest-junit": "^16.0.0",
         "multer": "^1.4.5-lts.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0"
@@ -5666,6 +5667,39 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.4.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.3.tgz",
@@ -9001,6 +9035,11 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.3.12",
     "@types/multer": "^1.4.7",
+    "jest-junit": "^16.0.0",
     "multer": "^1.4.5-lts.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0"
@@ -69,6 +70,25 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
+    "coverageReporters": [
+      "html",
+      "json-summary",
+      "text",
+      "text-summary",
+      "lcov"
+    ],
+    "reporters": [
+      "default",
+      [
+        "jest-junit",
+        {
+          "outputDirectory": "coverage"
+        }
+      ]
+    ],
+    "coveragePathIgnorePatterns": [
+      "node_modules"
+    ],
     "verbose": true
   }
 }


### PR DESCRIPTION
# Changelog
## `.github/workflows/continous-deployment.yaml`
* Adds a CD pipeline that runs when PRs are merged into the `main` branch, should update the status badge in the readme with new coverage values for `main` and will rebuild the docker container before pushing that up and deploying to Cloud Run
## `.github/workflows/continuous-integration.yaml`
* Changes this to be on PR rather than pushes into `main`, also adds caching and generating a coverage comment on the PR
## `README.md`
* Add badge for coverage tracking in readme
## `package.json`
* Add coverage generation for running tests, allows us to generate coverage comment/badges